### PR TITLE
chore: pause thoughts

### DIFF
--- a/app/_w.generator.ts
+++ b/app/_w.generator.ts
@@ -10,6 +10,8 @@ export interface WritingPost {
   tags?: string[]
 }
 
+const PUBLISHED_WRITING_SLUGS = new Set<string>()
+
 export function extractMetadataString(source: string, key: string) {
   const match = source.match(
     new RegExp(`${key}:\\s*("(?:\\\\.|[^"])*"|'(?:\\\\.|[^'])*')`),
@@ -67,6 +69,13 @@ export async function generateWritings() {
     if (!(entry.isFile() && entry.name === 'page.mdx')) {
       continue
     }
+    const relativePath = path.relative(writingsDir, entry.path)
+    const slug = `/t/${relativePath}`.replace(/\\/g, '/')
+
+    if (!PUBLISHED_WRITING_SLUGS.has(slug)) {
+      continue
+    }
+
     const filePath = path.join(entry.parentPath, entry.name)
     const content = await fs.readFile(filePath, 'utf-8')
 
@@ -78,9 +87,8 @@ export async function generateWritings() {
       continue
     }
 
-    const relativePath = path.relative(writingsDir, entry.path)
     writings.push({
-      slug: `/t/${relativePath}`.replace(/\\/g, '/'),
+      slug,
       ...metadata,
     })
   }
@@ -91,12 +99,14 @@ export async function generateWritings() {
   )
 
   // If no hero is set, set the first element as hero
-  if (!writings.some((w) => w.hero)) {
+  if (writings.length > 0 && !writings.some((w) => w.hero)) {
     writings[0].hero = true
   }
 
   const fileContent = `// This file is auto-generated. Do not edit it manually.
-export const ALL_WRITINGS = ${JSON.stringify(writings, null, 2)} as const;
+import type { WritingPost } from './_w.generator'
+
+export const ALL_WRITINGS = ${JSON.stringify(writings, null, 2)} as readonly WritingPost[];
 `
 
   await fs.writeFile(path.join(process.cwd(), 'app', '_w.ts'), fileContent)

--- a/app/_w.ts
+++ b/app/_w.ts
@@ -1,46 +1,4 @@
 // This file is auto-generated. Do not edit it manually.
-export const ALL_WRITINGS = [
-  {
-    "slug": "/t/dev-tools-that-bring-me-joy",
-    "title": "A couple dev tools that bring me joy",
-    "description": "A short note on the dev tools I keep recommending because they make it easier to close the loop.",
-    "date": "04/04/2026",
-    "hero": false,
-    "tags": [
-      "tech",
-      "dev tooling"
-    ]
-  },
-  {
-    "slug": "/t/we-only-need-mcps-because-we-dont-trust-llms",
-    "title": "We only need MCPs because we don't trust LLMs",
-    "description": "MCPs make sense when models are untrusted, but long-term safety should come from sandboxed environments and scoped access.",
-    "date": "03/12/2026",
-    "hero": false,
-    "tags": [
-      "tech",
-      "dev tooling"
-    ]
-  },
-  {
-    "slug": "/t/no-handbook",
-    "title": "There Is No Handbook",
-    "description": "On building mental models and navigating uncertainty in the age of coding agents.",
-    "date": "10/21/2025",
-    "hero": true,
-    "tags": [
-      "tech",
-      "dev tooling"
-    ]
-  },
-  {
-    "slug": "/t/to-think",
-    "title": "Struggling to Think.",
-    "description": "A personal reflection on the importance of writing for clear thinking.",
-    "date": "03/01/2025",
-    "hero": false,
-    "tags": [
-      "tech"
-    ]
-  }
-] as const;
+import type { WritingPost } from './_w.generator'
+
+export const ALL_WRITINGS = [] as readonly WritingPost[];

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -90,7 +90,7 @@ export default function HomePage() {
 }
 
 function AnimatedTabsHover() {
-  const TABS = ['About', /* 'Fun', */ 'Thoughts', 'Experience', 'Contact'] as const;
+  const TABS = ['About', /* 'Fun', */ 'Experience', 'Contact'] as const;
   const router = useRouter();
   const searchParams = useSearchParams();
   const activeTab = searchParams.get('tab') || TABS[0];
@@ -164,7 +164,7 @@ function AnimatedTabsHover() {
         </motion.section>
       )} */}
 
-      {activeTab === TABS[1] && (
+      {false && activeTab === 'Thoughts' && (
         <motion.section
           variants={VARIANTS_SECTION}
           initial="hidden"
@@ -209,7 +209,7 @@ function AnimatedTabsHover() {
         </motion.section>
       )}
       
-      {activeTab === TABS[2] && (
+      {activeTab === 'Experience' && (
         <motion.section
           variants={VARIANTS_SECTION}
           initial="hidden"
@@ -217,7 +217,7 @@ function AnimatedTabsHover() {
           transition={TRANSITION_SECTION}
           key="experience-section"
         >
-          <div className="flex flex-col space-y-3 max-w-11/12 mx-auto">
+          <div className="group/list flex flex-col max-w-11/12 mx-auto">
             <div className='mb-10'>
               <InfiniteSlider speedOnHover={20} gap={24}>
                 {WORK_EXPERIENCE.map(({img_src, company}, index) => (
@@ -232,7 +232,7 @@ function AnimatedTabsHover() {
             </div>
             {WORK_EXPERIENCE.map(({link, title, company, achievement_summary, start, end}, i) => (
               <a
-                className="relative overflow-hidden p-[1px] border-b hover:bg-foreground/5 hover:rounded-xl"
+                className="relative overflow-hidden border-b p-[1px] py-3 transition-opacity duration-300 group-hover/list:opacity-20 hover:!opacity-100"
                 href={link}
                 target="_blank"
                 rel="noopener noreferrer"
@@ -254,7 +254,7 @@ function AnimatedTabsHover() {
         </motion.section>
       )}
       
-      {activeTab === TABS[3] && (
+      {activeTab === 'Contact' && (
         <motion.section
           variants={VARIANTS_SECTION}
           initial="hidden"


### PR DESCRIPTION
- Removes Thoughts from the home tabs while keeping the archived Thoughts block in code.
- Pauses all published writing entries without special-casing the MCP post.
- Reuses the Thoughts hover-fade list treatment for Experience entries.
- Validation: bun test app/_w.generator.test.ts; env NEXT_TELEMETRY_DISABLED=1 bun run build.